### PR TITLE
Begin modernizing use of strings

### DIFF
--- a/src/sd.h
+++ b/src/sd.h
@@ -6451,8 +6451,7 @@ extern SDLIB_API heritflags simple_herit_bits_table[];              /* in SDTOP 
 
 
 struct comment_block {
-   char txt[MAX_TEXT_LINE_LENGTH];
-   comment_block *nxt;
+   std::string txt;
 };
 
 // A few accessors to let the UI stuff survive.  They are implemented, for now, in SDTOP.

--- a/src/sd.h
+++ b/src/sd.h
@@ -91,6 +91,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <string>
 
 #include "database.h"
 #include "sdchars.h"
@@ -2468,7 +2469,7 @@ public:
    uims_reply_thing full_resolve();
    void write_aproximately();
    void write_resolve_text(bool doing_file);
-   void writestuff(const char *s);
+   void writestuff(std::string_view s);
    void show_match_item();
    void print_error_person(unsigned int person, bool example);  // In sdmain
    void printperson(uint32_t x);

--- a/src/sdmain.cpp
+++ b/src/sdmain.cpp
@@ -813,8 +813,7 @@ extern bool query_for_call()
                if (gg77->iob88.get_popup_string("*Enter comment:", "", "Enter comment:", "", comment) ==
                    POPUP_ACCEPT_WITH_STRING) {
                   comment_block *new_comment_block = new comment_block;
-                  char *temp_text_ptr = new_comment_block->txt;
-                  string_copy(&temp_text_ptr, comment);
+                  new_comment_block->txt = comment;
 
                   *parse_state.concept_write_ptr = parse_block::get_parse_block();
                   (*parse_state.concept_write_ptr)->concept = &concept_marker_concept_comment;

--- a/src/sdutil.cpp
+++ b/src/sdutil.cpp
@@ -2337,9 +2337,9 @@ void ui_utils::doublespace_file()
 }
 
 
-void ui_utils::writestuff(const char *s)
+void ui_utils::writestuff(std::string_view s)
 {
-   while (*s) writechar(*s++);
+   for (char ch : s) writechar(ch);
 }
 
 void ui_utils::show_match_item()


### PR DESCRIPTION
2 small changes:
- generalize writestuff() by taking std::string_view
- use std::string in struct comment_block

Testing:
- compiles and runs on linux
- regression tests pass (and they use lots of comments)