### PR TITLE
This is src and doc for version 39.84

### DIFF
--- a/doc/about.lst
+++ b/doc/about.lst
@@ -1,5 +1,5 @@
 Sd -- Square Dance Caller's Helper for Windows ®
 This program may be distributed under certain conditions;
 for details see the GNU General Public License at COPYING.txt
-SD Version 39.83:   Copyright © 1990-2026 All rights reserved.
+SD Version 39.84:   Copyright © 1990-2026 All rights reserved.
 William B. Ackerman and Stephen Gildea

--- a/doc/index2.htmli
+++ b/doc/index2.htmli
@@ -7,7 +7,7 @@ Sd: a checker-moving program that is <strong>powerful</strong>,
 <strong>reliable</strong>.
 </p>
 <p align="center">
-<strong>The current version of Sd/Sdtty is 39.83</strong>, released on Mar 15, 2026.
+<strong>The current version of Sd/Sdtty is 39.84</strong>, released on Jul 4, 2026.
 <p align="center">
 <strong>This reflects recent changes in the C3 list.</strong>
 

--- a/doc/relnotes.txi
+++ b/doc/relnotes.txi
@@ -10,8 +10,8 @@
 @end iftex
 @c %**end of header
 
-@set title1 RELEASE NOTES FOR VERSION 39.83
-@set title2 Database version = 39.83 format = 430
+@set title1 RELEASE NOTES FOR VERSION 39.84
+@set title2 Database version = 39.84 format = 433
 @set title3 parser version 1.13, X11 UI version 1.17, SD UI version 4.10
 
 @node Top, Intro, (dir), (dir)
@@ -23,6 +23,7 @@ versions of the Sd program.
 * Intro::               Information about the current version
 
 Changes as of the following versions:
+* 39.84::
 * 39.83::
 * 39.82::
 * 39.81::
@@ -183,7 +184,7 @@ and @file{relnotes98.txi} have
 notes relating to even older versions.
 @end menu
 
-@node Intro, 39.83, Top, (dir)
+@node Intro, 39.84, Top, (dir)
 
 @center @titlefont{@value{title1}}@*
 @center @value{title2}@*
@@ -194,11 +195,38 @@ notes relating to even older versions.
 @noindent Copyright @copyright{} 1996-2026 William B. Ackerman
 @sp 3
 @menu
-* 39.83::               Changes in the current version
+* 39.84::               Changes in the current version
 @end menu
 
 @c ************
-@node 39.83, 39.82, Intro, Top
+@node 39.84, 39.83, Intro, Top
+@unnumberedsec Version 39.84 changes
+
+Deal with tricky aspects of @strong{split circulate}.
+@sp 1
+Handle @strong{strut right/left} with single stable in big matrix.
+@sp 1
+Fix bug in @strong{zip the top}.
+@sp 1
+Improve @strong{mesh}.
+@sp 1
+Improve @strong{roll out to a column}.
+@sp 1
+Improve @strong{lock 'em up}.
+@sp 1
+Improve @strong{central interlocked ramble}.
+@sp 1
+Fix the wrong-handed collision in @strong{the action}.
+@sp 1
+Improved handling of @strong{stable}.
+@sp 1
+Improved handling of outside diamonds.
+@sp 1
+Treat @strong{parallelogram} and @strong{split phantom whatever}
+as a single concept when used under stuff like @strong{initially}.
+
+@c ************
+@node 39.83, 39.82, 39.84, Top
 @unnumberedsec Version 39.83 changes
 
 Better handling of triple general 1/4 tag setups, with an alternative

--- a/doc/sd_doc.txi
+++ b/doc/sd_doc.txi
@@ -1,8 +1,8 @@
 \input texinfo
 @c user documentation for Sd (square dance caller's helper)
 @c
-@set sd-version 39.83
-@set Time-stamp: Mar 25, 2026
+@set sd-version 39.84
+@set Time-stamp: Jul 4, 2026
 @c
 @setfilename sd_doc.info
 @c We want the version number to show in the html file.

--- a/src/database.h
+++ b/src/database.h
@@ -45,7 +45,7 @@
 // database format version.
 
 #define DATABASE_MAGIC_NUM 21316
-#define DATABASE_FORMAT_VERSION 430
+#define DATABASE_FORMAT_VERSION 433
 
 
 // We used to do some stuff to cater to compiler vendors (e.g. Sun
@@ -375,6 +375,7 @@ const uint64_t INHERITFLAG_ZOOMROLL   = 0x0000080000000000ULL;
 const uint64_t INHERITFLAG_TRADE      = 0x0000100000000000ULL;
 const uint64_t INHERITFLAG_CROSSOVER  = 0x0000200000000000ULL;
 const uint64_t INHERITFLAG_RECTIFY    = 0x0000400000000000ULL;
+const uint64_t INHERITFLAG_STABLE     = 0x0000800000000000ULL;
 
 
 typedef uint64_t heritflags;
@@ -1106,6 +1107,7 @@ enum call_restriction {
    cr_said_galaxy,         // Qualifier only.
    cr_not_funny,           // Qualifier only.
    cr_didnt_say_matrix,    // Qualifier only.
+   cr_phantom_in_use,      // Qualifier only.
    cr_occupied_as_stars,   // Qualifier only.
    cr_occupied_as_clumps,  // Qualifier only.
    cr_occupied_as_blocks,  // Qualifier only.
@@ -1124,6 +1126,7 @@ enum call_restriction {
    cr_people_1_opp_real,   // Qualifier only.
    cr_people_12_opp_real,  // Qualifier only.
    cr_people_34_opp_real,  // Qualifier only.
+   cr_people_0_opp_phan,   // Qualifier only.
    cr_consistent_roll,     // Qualifier only.
    cr_slide_seems_good,
    cr_ctrs_sel,

--- a/src/db_doc.txt
+++ b/src/db_doc.txt
@@ -2071,6 +2071,11 @@ pgdmdccw    |  6  |  7  |  |  4  |
 normal_concentric  ??????
 
 
+================== ARRAY CALL DEFINITIONS ==================
+
+The fundamental definition mechanism is the "array" call.  All others
+use some keyword to indicate the type.
+
 An important property of these setups, used extensively by the program,
 is that any person's diagonal opposite can be found by adding half the
 setup size modulo the setup size.  Additionally, for setups that have
@@ -2722,6 +2727,76 @@ appear is not significant -- the search is always from the largest
 setup to the smallest.  Multiple specifications with the same
 starting setup are only meaningful if qualifiers are used (see below),
 and, in that case, they are searched in the order in which they appear.
+
+
+================== MATRIX CALL DEFINITIONS ==================
+
+This includes "matrix", "partnermatrix", and "partnerpartialmatrix".  The keyword
+is followed by zero or more attributes, from this list:
+
+use_selector
+stop_and_warn_on_tbone
+tbone_is_ok
+ignore_nonselectees
+must_face_same_way
+find_jaywalkers
+both_selected_ok
+find_squeezers
+find_spreaders
+find_traders
+use_veer_data
+use_number
+lateral_mirror_if_right_of_center
+only_in
+only_out
+add_2n
+include_phantoms
+not_true_invader
+selector_is_trailers
+do_half_of_ctr_rot
+
+For "partnermatrix" and "partnerpartialmatrix", this is followed by 4 groups of
+8 specifiers each.
+
+Each specifier for a person is either:
+   a pair of two tokens, as X offset, with decorations, and Y offset, as just a number.
+or
+   a single zero, meaning that action is illegal
+
+Each specifier is given with an offset, calibrated the usual way --- a matrix position
+counts as 4.  They are in "excess 16" form --- 16 is stationary, 12 is one matrix
+position in the negative X direction, etc.
+The decorations are the usual --- L/M/R for roll, A/C for stability, F/G
+for slide direction, left or right.
+
+The full definition for a call has 2 major groups of 8 specifiers each.  In each group
+The specifiers are the Cartesian product of {non-selected, selected} x {beau, belle} x
+{boy,girl}.
+
+For all calls except "squeeze", only the first group is used, as above, so the
+definition ends with 8 specifiers of zero.  Calls with the "find_squeezers" property
+set ("squeeze" and "<anyone> squeeze") use the second group.  In this case the first
+group is for people who are close (trade and slide apart) and the second is for people
+who are far apart (slide together and trade.)
+
+Here is "@6 shove off":
+   partnermatrix use_selector stop_and_warn_on_tbone
+      [ZGM20N 16 ZGM20N 16 ZFM12N 16 ZFM12N 16 AGL12S 16 AGL12S 16 CFR20S 16 CFR20S 16
+       <- boy -> <-girl -> <- boy -> <-girl -> <- boy -> <-girl -> <- boy -> <-girl -> 
+       <-      beau     -> <-      belle    -> <-      beau     -> <-      belle    ->
+       <-    non-designee (not selected)    -> <-        designee (selected)        ->
+
+      0 0 0 0 0 0 0 0]   // Second group, not used.
+
+For plain "matrix" calls (e.g. "truck"), there are just 4 specifiers, for boy/girl and
+beau/belle.
+
+============= OTHER CALLS (sequential, concentric, etc.) =============
+
+FINISH THIS.
+
+
+
 
         OVERVIEW OF PREDICATES, RESTRICTIONS, AND QUALIFIERS
 
@@ -4069,6 +4144,11 @@ These restrictions are "overloaded" -- their meaning depends on the starting set
                                        T-boned, and it just tests that each person is a
                                        leader or trailer in his 2x2.  This should be used
                                        with the "in" or "out" mofifier, of course.
+
+   people_1_opp_real       R/Q      Person #1, and his opposite in this setup, is real.
+   people_12_opp_real      R/Q      People #1 and 2, and their opposites in this setup, are both real.
+   people_34_opp_real      R/Q      People #3 and 4, and their opposites in this setup, are both real.
+   people_0_opp_phan       R/Q      Person #0, and his opposite in this setup, is not real.
 
    dmd_intlk          Really ought to document this!   Live
    dmd_not_intlk      Really ought to document this!   Live

--- a/src/makefile.mingw64
+++ b/src/makefile.mingw64
@@ -6,7 +6,7 @@
 CC = g++ -static-libgcc -static-libstdc++
 
 # This gives any "-D" switches that we always need to send to the compiler.
-DEFS = -Wall -Wno-switch -Wno-uninitialized -Wno-char-subscripts -Wno-narrowing \
+DEFS = -Wall -Wno-switch -Wno-char-subscripts -Wno-narrowing \
        -Wno-stringop-truncation -Wno-stringop-overflow -Wno-format-overflow
 
 # This gives the optimization and/or debug info.  These flags presumably

--- a/src/mkcalls.cpp
+++ b/src/mkcalls.cpp
@@ -927,6 +927,7 @@ const char *qualtab[] = {
    "said_galaxy",
    "not_funny",
    "didnt_say_matrix",
+   "phantom_in_use",
    "occupied_as_stars",
    "occupied_as_clumps",
    "occupied_as_blocks",
@@ -945,6 +946,7 @@ const char *qualtab[] = {
    "people_1_opp_real",
    "people_12_opp_real",
    "people_34_opp_real",
+   "people_0_opp_phan",
    "roll_is_consistent",
    "slide_seems_good",
    "centers_sel",
@@ -1160,6 +1162,7 @@ const char *flagtabh[] = {
    "trade_is_inherited",
    "crossover_is_inherited",
    "rectify_is_inherited",
+   "stable_is_inherited",
    ""};
 
 // This table is keyed to the constants "INHERITFLAG_???".
@@ -1212,6 +1215,7 @@ const char *altdeftabh[] = {
    "trade",
    "crossover",
    "rectify",
+   "stable",
    ""};
 
 // See INHERITFLAG_YOYOETCMASK in database.h
@@ -1355,6 +1359,7 @@ const char *defmodtabh[] = {
    "inherit_trade",
    "inherit_crossover",
    "inherit_rectify",
+   "inherit_stable",
    ""};
 
 // This table is keyed to the constants "dfm_***".  These are the heritable
@@ -1411,6 +1416,7 @@ const char *forcetabh[] = {
    "force_trade",
    "force_crossover",
    "force_rectify",
+   "force_stable",
    ""};
 
 // This table is keyed to the constants "MTX_???".

--- a/src/sd.h
+++ b/src/sd.h
@@ -1827,6 +1827,9 @@ struct resultflag_rec {
    }
 };
 
+// Attempting to increase this will run afoul of many things, including
+// collision_collector::fix_possible_collision, and the various
+// "get_directions" things.
 enum { MAX_PEOPLE = 32 };
 
 struct small_setup {
@@ -4846,6 +4849,7 @@ enum part_key_kind {
 
 // BEWARE!!  This list is keyed to the table "meta_key_props" in sdtables.cpp .
 enum meta_key_kind {
+   meta_key_none,
    meta_key_random,
    meta_key_rev_random,   // Must follow meta_key_random.
    meta_key_piecewise,
@@ -5403,14 +5407,17 @@ struct skipped_concept_info {
    parse_block *m_result_of_skip;
    parse_block **m_root_of_result_of_skip;
    uint32_t m_nocmd_misc3_bits;
+   meta_key_kind m_meta_key = meta_key_none;
 
    skipped_concept_info() : m_nocmd_misc3_bits(0) {}
-   skipped_concept_info(parse_block *incoming) THROW_DECL;    // In SDTOP
+   skipped_concept_info(parse_block *incoming,
+                        meta_key_kind meta_key = meta_key_none) THROW_DECL;    // In SDTOP
    parse_block *get_next() {
       parse_block *t = (m_heritflag != 0ULL) ? m_concept_with_root : m_result_of_skip;
       if (!t)
          fail("Need a concept.");
-      return t; }
+      return t;
+   }
 };
 
 extern bool check_for_concept_group(
@@ -5743,6 +5750,7 @@ public:
 
    // Simple constructor, takes argument saying whether collisions will be legal.
    collision_collector(setup *const result, collision_severity allow):
+      m_beware_mystic_collision(false),
       m_result_ptr(result),
       m_allow_collisions(allow),
       m_collision_mask(0),
@@ -5753,7 +5761,8 @@ public:
       m_cmd_misc_flags(0),
       m_collision_appears_illegal(1),  // Halfway between "appears_illegal"
                                        // and not -- use table item.
-      m_result_mask(0)
+      m_result_mask(0),
+      m_extra_collided_people(*result)
    {
       m_extra_collided_people.clear_people();
    }
@@ -5761,6 +5770,7 @@ public:
    // Glorious constructor, takes all sorts of stuff.
    collision_collector(setup *const result, bool mirror,
                        setup_command *cmd, uint64_t callflags1):
+      m_beware_mystic_collision(false),
       m_result_ptr(result),
       m_allow_collisions(collision_severity_ok),
       m_collision_mask(0),
@@ -5770,7 +5780,8 @@ public:
       m_doing_half_override(false),
       m_cmd_misc_flags(cmd->cmd_misc_flags),
       m_collision_appears_illegal(0),  // May change to 2 as call progresses.
-      m_result_mask(0)
+      m_result_mask(0),
+      m_extra_collided_people(*result)
    {
       m_extra_collided_people.clear_people();
       // If doing half of a call, and doing it left,
@@ -5787,16 +5798,17 @@ public:
    uint32_t * install_with_collision(
       int resultplace,
       const setup *sourcepeople, int sourceplace,
-      int rot,
-      bool stop_on_collision = false) THROW_DECL;
+      int rot) THROW_DECL;
 
    void fix_possible_collision(merge_action_type action = merge_strict_matrix,
                                uint32_t callarray_flags = 0,
                                setup *ss = (setup *) 0) THROW_DECL;
 
+public:
+   bool m_beware_mystic_collision;
+
 private:
    setup *const m_result_ptr;
-   setup m_extra_collided_people;
    const collision_severity m_allow_collisions;
    int m_collision_index;
    uint32_t m_collision_mask;
@@ -5810,6 +5822,7 @@ private:
    // used when a collision occurs between the two groups doing an "own the anyone" operation.
    int m_collision_appears_illegal;
    uint32_t m_result_mask;
+   setup m_extra_collided_people;
 };
 
 extern void mirror_this(setup *s) THROW_DECL;
@@ -5868,7 +5881,8 @@ extern uint32_t do_call_in_series(
    bool qtfudged) THROW_DECL;
 
 extern void brute_force_merge(const setup *res1, const setup *res2,
-                              merge_action_type action, setup *result) THROW_DECL;
+                              merge_action_type action, bool beware_mystic_collision,
+                              setup *result) THROW_DECL;
 
 extern void drag_someone_and_move(setup *ss, parse_block *parseptr, setup *result) THROW_DECL;
 

--- a/src/sd.rc
+++ b/src/sd.rc
@@ -190,7 +190,7 @@ BEGIN
                     IDC_STATIC,53,19,144,8
     CTEXT           "conditions; for details see the file COPYING.txt.",
                     IDC_STATIC,53,29,148,8
-    CTEXT           "SD Version 39.83:   Copyright © 1990-2026 All rights reserved.",
+    CTEXT           "SD Version 39.84:   Copyright © 1990-2026 All rights reserved.",
                     IDC_STATIC,13,42,199,8
     CTEXT           "William B. Ackerman and Stephen Gildea",IDC_STATIC,47,
                     52,130,8

--- a/src/sd_calls.txt
+++ b/src/sd_calls.txt
@@ -55,7 +55,7 @@
 //    string is also required by paragraphs 2(a) and 2(c) of the GNU
 //    General Public License if you distribute the file.
 
-version "39.83"
+version "39.84"
 
 call "nothing" xyz tag nullcall
             dont_use_in_resolve dont_raise_overcast
@@ -559,7 +559,7 @@ call "split@O circulate@P" xyz tag split_circ
    setup 2x2 2x2 no_cutting_through
       array [CR1S AL0S ZM1N ZM0N]
             alternate_definition [half] xyz
-   setup 2x2 dmd rotate no_cutting_through restriction wave_only
+   setup 2x2 dmd rotate restriction wave_only
       array [CR0N AL0S ZM1W ZM3W]
             alternate_definition [lasthalf] xyz
    setup dmd 2x2 restriction forbidden diamond_like qualifier right dmd_ctrs_mwv
@@ -5740,6 +5740,7 @@ call "@6 run the wheel" c4a
 call "bridge the gap" c4a
    partnerpartialmatrix tbone_is_ok include_phantoms not_true_invader
       [ZM12N 20 ZM12N 20 AL12S 20 AL12S 20 0 0 0 0 0 0 0 0 0 0 0 0]
+
    setup 4x2 2x4 rotate
       array [ZM7W ZM0W 0 0 0 0 AL1E AL6E]
             alternate_definition [generous] c3
@@ -8039,10 +8040,18 @@ call "do-sa-do" xyz
    seq dosodo2 [inherit_left]
 
 call "touch" xyz tag touch
-            // The "rear back" property is required for square thru, etc.
-           /* rear_back_from_r_wave */ left_means_mirror
+            left_means_mirror
    setup 2x1 1x2 rotate qualifier in in_or_out
       array [ZM0W 0]
+            parallel_conc_end
+   setup 4x1 2x2 qualifier in in_or_out
+      predscantdocallinsetup
+         if 4x1_facing_someone [ZM0N 0 0 ZM1N]
+         if always [0 0 0 0]
+   setup 4x1 dmd
+      predscantdocallinsetup
+         if 4x1_facing_someone [0 ZM1N 0 ZM2N]
+         if always [0 0 0 0]
    // This is for handling things from a triangle-become-box.  Cf. t42t.
    setup 2x2 1x4 no_cutting_through qualifier in in_or_out
       array [0 0 ZM3N ZM0N]
@@ -8871,35 +8880,75 @@ call "quadruple pass thru" c1   // You're right!  It isn't on the list!
 
 call "strut right" c3
             rear_back_from_qtag
-            single_is_inherited twisted_is_inherited
+            single_is_inherited twisted_is_inherited stable_is_inherited
             bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
    seq ctrs_pass_thru [inherit_single inherit_twisted
                        inherit_bigmatrix inherit_nxn inherit_mxn]
    seq finish_strut_right [inherit_single inherit_nxn inherit_mxn]
+            single_is_inherited twisted_is_inherited stable_is_inherited
+            bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
+   setup 1x1 1x1
+      array [0]
+            alternate_definition [single stable 4x4] c4
+   setup 8x1 1x8 rotate
+      array [ZM6W ZM7W ZM4W ZM5W 0 0 0 0]
+            alternate_definition [single stable 3x3] c4
+   setup 6x1 1x6 rotate
+      array [ZM5W ZM4W ZM3W 0 0 0]
 
 call "strut left" c3
             rear_back_from_qtag
-            single_is_inherited twisted_is_inherited
+            single_is_inherited twisted_is_inherited stable_is_inherited
             bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
    seq ctrs_pass_thru [inherit_single inherit_twisted
                        inherit_bigmatrix inherit_nxn inherit_mxn]
    seq finish_strut_right [force_left inherit_single inherit_nxn inherit_mxn]
+            single_is_inherited twisted_is_inherited stable_is_inherited
+            bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
+   setup 1x1 1x1
+      array [0]
+            alternate_definition [single stable 4x4] c4
+   setup 8x1 1x8 rotate
+      array [ZM2W ZM3W ZM0W ZM1W 0 0 0 0]
+            alternate_definition [single stable 3x3] c4
+   setup 6x1 1x6 rotate
+      array [ZM2W ZM1W ZM0W 0 0 0]
 
 call "strut right and left" c3
             rear_back_from_qtag
-            single_is_inherited twisted_is_inherited
+            single_is_inherited twisted_is_inherited stable_is_inherited
             bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
    seq ctrs_pass_thru [inherit_single inherit_twisted
                        inherit_bigmatrix inherit_nxn inherit_mxn]
    seq finish_strut_right_and_left [inherit_single inherit_nxn inherit_mxn]
+            single_is_inherited twisted_is_inherited stable_is_inherited
+            bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
+   setup 1x1 1x1
+      array [0]
+            alternate_definition [single stable 4x4] c4
+   setup 8x1 1x8 rotate
+      array [ZM1W ZM2W ZM4W ZM7W 0 0 0 0]
+            alternate_definition [single stable 3x3] c4
+   setup 6x1 1x6 rotate
+      array [ZM1W ZM5W ZM3W 0 0 0]
 
 call "strut left and right" c3
             rear_back_from_qtag
-            single_is_inherited twisted_is_inherited
+            single_is_inherited twisted_is_inherited stable_is_inherited
             bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
    seq ctrs_pass_thru [inherit_single inherit_twisted
                        inherit_bigmatrix inherit_nxn inherit_mxn]
    seq finish_strut_right_and_left [force_left inherit_single inherit_nxn inherit_mxn]
+            single_is_inherited twisted_is_inherited stable_is_inherited
+            bigmatrix_is_inherited nxn_is_inherited mxn_is_inherited
+   setup 1x1 1x1
+      array [0]
+            alternate_definition [single stable 4x4] c4
+   setup 8x1 1x8 rotate
+      array [ZM5W ZM6W ZM0W ZM3W 0 0 0 0]
+            alternate_definition [single stable 3x3] c4
+   setup 6x1 1x6 rotate
+      array [ZM4W ZM2W ZM0W 0 0 0]
 
 call "_finish strut right" dontshow tag finish_strut_right
             left_means_mirror
@@ -10970,7 +11019,7 @@ call "zip the top" c4a
    setup dmd 1x4 rotate
       array [CR0N 0 AL0S 0]
    setup pmd 1x4 rotate
-      array [0 CR1E 0 AL1E]
+      array [0 CR1E 0 AL3E]
             alternate_definition [fractal] c4
    setup 1x4 1x4 rotate no_cutting_through
       array [CR0N CR3N AL0S AL3S]
@@ -17145,6 +17194,12 @@ call "arky star thru" c4a
 
 call "mesh" c4
             reverse_means_mirror
+   // Centers only in a 4x1 mesh *with each other*.
+   // This qualifier is actually "0 and 2 phan, 1 and 3 real.
+   // which is a stupid way of expressing it.
+   /// Should be "mask==0xA" or something like that.
+   setup 4x1 1x2 rotate qualifier people_0_opp_phan
+      array [0 M1W 0 M0W]
    // We disapprove of back-to-back.
    setup 2x1 1x2 rotate qualifier all_facing_same
       array [M1W M0W]
@@ -20770,6 +20825,9 @@ call "roll out to a column" c4a
             left_means_mirror take_right_hands
    setup 4x2 2x4 restriction unusual 2fl_only
       array [0 CA5N C6S C4S C5S C7S CA4N 0]
+   // In some phantom situations, we could be in a CDPT with ends missing.
+   setup 2x2 2x4 rotate qualifier phantom_in_use
+      array [C2E C3E 0 0]
             alternate_definition [single] c4
    // From a trade-by, this is ambiguous, resolved only by people
    // crashing and wondering whether they should take right hands
@@ -23989,7 +24047,7 @@ call "box circulate" xyz tag box_circ
    setup 2x2 2x2 no_cutting_through
       array [CR1S AL0S ZM1N ZM0N]
             alternate_definition [half] xyz
-   setup 2x2 dmd rotate no_cutting_through
+   setup 2x2 dmd rotate
       array [CR0N AL0S ZM1W ZM3W]
    setup 2x1 1x2 rotate
       array [ZM0W 0]
@@ -27657,42 +27715,47 @@ call "hinge the top" c3a
    seq fanthetop [inherit_fractal]
 
 call "_lock em up 3" dontshow tag lockemup3
-            fractal_is_inherited rectify_is_inherited
-   conc hinge [inherit_fractal] ctr_rot [inherit_rectify conc_force_otherway]
+            rectify_is_inherited fractal_is_inherited gen_sting_is_inherited
+   conc hinge [inherit_fractal inherit_gensting] ctr_rot [inherit_rectify conc_force_otherway]
 
 call "_lock em up 4" dontshow tag lockemup4
-            fractal_is_inherited
-   conc lockit [inherit_fractal] roll []
+            fractal_is_inherited gen_sting_is_inherited
+   conc lockit [inherit_fractal inherit_gensting] roll []
 
 call "_lock em up 4 but @m" dontshow tag lockemup4but
    conc nullsecond [mandatory_secondary_call] roll []
 
 call "lock 'em up" c3
-            visible_fractions cross_is_inherited fractal_is_inherited rectify_is_inherited
-   seq lockit [inherit_cross inherit_fractal]
-   seq hinge [inherit_fractal]
-   seq lockemup3 [inherit_fractal inherit_rectify]
-   seq lockemup4 [inherit_fractal]
+            visible_fractions cross_is_inherited rectify_is_inherited
+            fractal_is_inherited gen_sting_is_inherited
+   seq lockit [inherit_cross inherit_fractal inherit_gensting]
+   seq hinge [inherit_fractal inherit_gensting]
+   seq lockemup3 [inherit_fractal inherit_rectify inherit_gensting]
+   seq lockemup4 [inherit_fractal inherit_gensting]
 
 call "@0 'em up" c4
-            visible_fractions fractal_is_inherited
+            visible_fractions rectify_is_inherited
+            fractal_is_inherited gen_sting_is_inherited
+
    seq nullcall [mandatory_anycall]
-   seq hinge [inherit_fractal]
-   seq lockemup3 [inherit_fractal]
-   seq lockemup4 [inherit_fractal]
+   seq hinge [inherit_fractal inherit_gensting]
+   seq lockemup3 [inherit_fractal inherit_rectify inherit_gensting]
+   seq lockemup4 [inherit_fractal inherit_gensting]
 
 call "lock 'em up but @m" c3
-            visible_fractions cross_is_inherited fractal_is_inherited
-   seq lockit [inherit_cross inherit_fractal]
-   seq hinge [inherit_fractal]
-   seq lockemup3 [inherit_fractal]
+            visible_fractions cross_is_inherited rectify_is_inherited
+            fractal_is_inherited gen_sting_is_inherited
+   seq lockit [inherit_cross inherit_fractal inherit_gensting]
+   seq hinge [inherit_fractal inherit_gensting]
+   seq lockemup3 [inherit_fractal inherit_rectify inherit_gensting]
    seq lockemup4but []
 
 call "@0 'em up but @m" c4
-            visible_fractions fractal_is_inherited
+            visible_fractions fractal_is_inherited gen_sting_is_inherited
+
    seq nullcall [mandatory_anycall]
-   seq hinge [inherit_fractal]
-   seq lockemup3 [inherit_fractal]
+   seq hinge [inherit_fractal inherit_gensting]
+   seq lockemup3 [inherit_fractal inherit_gensting]
    seq lockemup4but []
 
 call "@2split @3the difference" c4a
@@ -28461,7 +28524,9 @@ call "_fold to face" dontshow tag foldtoface
    setup 1x4 2x2 restriction forbidden wave_only
       array [CR1S CR1S AL0S AL0S]
             alternate_definition [interlocked] c3
-   setup 1x4 2x2 restriction forbidden 2fl_only
+   setup 1x4 2x2 qualifier 2fl_only
+      array [CR0S CR1S AL1S AL0S]
+   setup 1x4 2x2 qualifier magic_only
       array [CR0S CR1S AL1S AL0S]
 
 call "_ramble part 1" dontshow tag ramble_1

--- a/src/sdbasic.cpp
+++ b/src/sdbasic.cpp
@@ -658,8 +658,7 @@ static collision_map collision_map_table[] = {
 uint32_t * collision_collector::install_with_collision(
    int resultplace,
    const setup *sourcepeople, int sourceplace,
-   int rot,
-   bool stop_on_collision /* = false */) THROW_DECL
+   int rot) THROW_DECL
 {
    if (resultplace < 0) fail("This would go into an excessively large matrix.");
    m_result_mask |= 1<<resultplace;
@@ -667,9 +666,8 @@ uint32_t * collision_collector::install_with_collision(
 
    if (m_result_ptr->people[resultplace].id1) {
       // We have a collision.
-      // Prepare the error message, in case it is needed.
-      if (stop_on_collision) return (uint32_t *) 0;
 
+      // Prepare the error message, in case it is needed.
       collision_person1 = m_result_ptr->people[resultplace].id1;
       collision_person2 = sourcepeople->people[sourceplace].id1;
       error_message1[0] = '\0';
@@ -730,15 +728,24 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
    if (!m_collision_mask) return;
 
    int i;
-   setup spare_setup = *m_result_ptr;
+   setup local_setup = *m_result_ptr;
    bool kill_ends = false;
    uint64_t lowbitmask = 0ULL;
+   uint64_t junk;
+   uint64_t localdirmask;
+   uint64_t extradirmask;
    collision_map *c_map_ptr;
 
    m_result_ptr->clear_people();
 
+   local_setup.big_endian_get_directions64(localdirmask, junk);
+   m_extra_collided_people.big_endian_get_directions64(extradirmask, junk);
+
+   // **** Can we use some "get_mask" function for this?
+   // If MAX_PEOPLE is more than 32, we are in trouble.
    for (i=0; i<MAX_PEOPLE; i++) {
-      lowbitmask |= ((uint64_t) (spare_setup.people[i].id1) & UINT64_C(1)) << i;
+      // One bit per person.
+      lowbitmask |= ((uint64_t) (local_setup.people[i].id1) & UINT64_C(1)) << i;
       lowbitmask |= ((uint64_t) (m_extra_collided_people.people[i].id1) & UINT64_C(1)) << (i+32);
    }
 
@@ -793,25 +800,27 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
          // rather than accept the table entry and deal with the warnings that it raises.
          // So we only do the "goto win" in certain circumstances.
 
-         if (c_map_ptr->warning == warn_bad_collision)
-            goto win;   // Entries with this warning always know exactly what they are doing.
+      if (c_map_ptr->warning == warn_bad_collision)
+         goto win;   // Entries with this warning always know exactly what they are doing.
 
-         // If doing real as_couples call, we reject certain maps and pick up the next one.
-         if (action == merge_c1_phantom_real_couples && (c_map_ptr->assume_key & 0x20000000))
-            continue;
+      // If doing real as_couples call, we reject certain maps and pick up the next one.
+      if (action == merge_c1_phantom_real_couples && (c_map_ptr->assume_key & 0x20000000))
+         continue;
 
-         if ((m_collision_appears_illegal & 6) ||
-             ((m_collision_appears_illegal & 1) &&
-              (c_map_ptr->assume_key & 0x80000000)))
-            continue;
-         else
-            goto win;
+      if ((m_collision_appears_illegal & 6) ||
+          ((m_collision_appears_illegal & 1) &&
+           (c_map_ptr->assume_key & 0x80000000)))
+         continue;
+      else
+         goto win;
    }
 
    // Don't recognize the pattern, report this as normal collision.
    throw error_flag_type(error_flag_collision);
 
  win:
+
+   bool handedness_warning = false;
 
    if ((callarray_flags & CAF__NO_CUTTING_THROUGH) && (c_map_ptr->assume_key & 0x08000000))
       fail("Call's collision has outsides cutting through the middle of the set.");
@@ -835,6 +844,7 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
          warn(warn__left_half_pass);
    }
    else {
+      handedness_warning = true;
       if (m_cmd_misc_flags & CMD_MISC__EXPLICIT_MIRROR)
          warn(warn__take_left_hands);
       else if (c_map_ptr->warning != warn__really_no_collision)
@@ -853,10 +863,10 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
    for (i=0; i<c_map_ptr->size; i++) {
       int oldperson;
 
-      oldperson = spare_setup.people[c_map_ptr->source[i]].id1;
+      oldperson = local_setup.people[c_map_ptr->source[i]].id1;
       install_rot(m_result_ptr,
                   (((oldperson ^ flip) & 2) ? c_map_ptr->map1 : c_map_ptr->map0)[i],
-                  &spare_setup,
+                  &local_setup,
                   c_map_ptr->source[i],
                   temprot);
 
@@ -867,6 +877,15 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
                   c_map_ptr->source[i],
                   temprot);
    }
+
+   // When centers and ends have different handedness, we do not want the original centers,
+   // when they collide and take hands, to be adjacent to each other.  Same with the ends.
+   // We want the final collided setup to have original centers and ends to be interleaved.
+   // Why is this the right thing?  No one knows.  But see Git issue #8, "mystic the action".
+
+   if (localdirmask == 0x802 && extradirmask == 0x208 && m_beware_mystic_collision &&
+       handedness_warning && m_result_ptr->kind == s2x8)
+      fail("Collision among groups of different handedness.");
 
    if (kill_ends) {
       const int8_t m3276[] = {3, 2, 7, 6};
@@ -881,14 +900,14 @@ void collision_collector::fix_possible_collision(merge_action_type action /*= me
            m_result_ptr->people[5].id1))
          fail("Need an assumption in order to take right hands at collision.");
 
-      spare_setup = *m_result_ptr;
+      local_setup = *m_result_ptr;
 
       if (m_result_ptr->kind == s_crosswave) {
-         gather(m_result_ptr, &spare_setup, m2367, 3, 033);
+         gather(m_result_ptr, &local_setup, m2367, 3, 033);
          m_result_ptr->rotation++;
       }
       else {
-         gather(m_result_ptr, &spare_setup, m3276, 3, 0);
+         gather(m_result_ptr, &local_setup, m3276, 3, 0);
       }
 
       m_result_ptr->kind = s1x4;
@@ -6112,7 +6131,6 @@ static uint32_t do_actual_array_call(
 
       CC.fix_possible_collision(action, goodies->callarray_flags, ss);
 
-
       if (specialhetero) {
          // result has line people's result,
          secondresult.kind = Lresult_kind;
@@ -6274,7 +6292,7 @@ extern void basic_move(
    heritflags search_temp_without_funny;
    heritflags search_temp_with_funny;
    int orig_elongation = 0;
-   bool four_way_startsetup;
+   bool four_way_startsetup = false;
    uint32_t newtb = tbonetest;
    uint32_t resultflagsmisc = 0;
    int desired_elongation = 0;

--- a/src/sdconc.cpp
+++ b/src/sdconc.cpp
@@ -3677,7 +3677,7 @@ extern void concentric_move(
          // Check for operating on a Z.
 
          uint32_t z_compress_direction99rot = begin_ptr->rotation;
-         uint32_t z_compress_direction99skew;
+         uint32_t z_compress_direction99skew = 0;
 
          if (begin_ptr->kind == s2x3 &&
              (analyzer == schema_concentric_zs ||
@@ -4327,7 +4327,7 @@ extern void concentric_move(
             else if (foocall == base_calls[base_call_circulate])
                localmodsout1 = DFM1_CONC_CONCENTRIC_RULES;
             else
-               localmodsout1 |= DFM1_CONC_CONCENTRIC_RULES;
+               localmodsout1 |= DFM1_CONC_FORCE_OTHERWAY;
          }
       }
    }
@@ -4960,6 +4960,7 @@ void merge_table::merge_setups(setup *ss,
    bool rose_from_dead = false;
    bool perp_2x4_1x8 = false;
    bool perp_2x4_ptp = false;
+   bool beware_mystic_collision = false;
    normalize_action na = normalize_before_merge;
 
    setup res2copy = *result;
@@ -5029,6 +5030,9 @@ void merge_table::merge_setups(setup *ss,
 
       uint32_t mask1 = res1->little_endian_live_mask();
       uint32_t mask2 = res2->little_endian_live_mask();
+
+      if ((res1->cmd.cmd_misc_flags ^ res2->cmd.cmd_misc_flags) & CMD_MISC__EXPLICIT_MIRROR)
+         beware_mystic_collision = true;
 
       if (res1->kind == s_qtag && res2->kind == s2x3 && !(mask1 & 0xCC)) {
          expand::compress_from_hash_table(res1, plain_normalize, mask1, false);
@@ -5326,7 +5330,7 @@ void merge_table::merge_setups(setup *ss,
              (maybe_the_call->the_defn.callflags1 & CFLAG1_TAKE_RIGHT_HANDS_AS_COUPLES))
             action = merge_c1_phantom_real_couples;
 
-         brute_force_merge(res1, res2, action, result);
+         brute_force_merge(res1, res2, action, beware_mystic_collision, result);
          goto final_getout;
       }
 
@@ -5582,7 +5586,7 @@ extern void punt_centers_use_concept(setup *ss, setup *result) THROW_DECL
    int crossconc = (cmd2word & CMD_MISC2__ANY_WORK_INVERT) ? 1 : 0;
    bool doing_yoyo = false;
    bool doing_do_last_frac = false;
-   parse_block *parseptrcopy;
+   parse_block *parseptrcopy = (parse_block *) 0;
 
    remove_z_distortion(ss);
 
@@ -8554,6 +8558,8 @@ extern void inner_selective_move(
       }
 
    done_with_this_one:
+
+      this_result->cmd.cmd_misc_flags = this_one->cmd.cmd_misc_flags;
 
       current_options.number_fields = svd_number_fields;
       current_options.howmanynumbers = svd_num_numbers;

--- a/src/sdconcpt.cpp
+++ b/src/sdconcpt.cpp
@@ -1478,7 +1478,7 @@ static void do_concept_parallelogram(
       fail("Can't do this concept with parallelogram.");
 
    if (no_overcast) ss->clear_all_overcasts();
-   divided_setup_move(ss, map_code, phancontrol, true, result);
+   divided_setup_move(ss, map_code, phancontrol, true, result, 0);
    if (no_overcast) result->clear_all_overcasts();
 
    // The split-axis bits are gone.  If someone needs them, we have work to do.
@@ -4137,7 +4137,7 @@ static void do_concept_phan_crazy(
    setup_command cmd = tempsetup.cmd;    // We will modify these flags, and, in any case,
                                          // we need to rematerialize them at each step.
 
-   uint32_t offsetmapcode;
+   uint32_t offsetmapcode = 0;
    uint32_t specialmapcode = ~0U;
 
    phantest_kind phanstuff = phantest_ok;
@@ -4553,6 +4553,23 @@ static void do_concept_stable(
    setup *result) THROW_DECL
 {
    if (process_brute_force_mxn(ss, parseptr, do_concept_stable, result)) return;
+
+   // Check for NXN given *before* stable.  Note that "stable" is not treated as
+   // an ordinary heritable flag, so it won't get combined with any other
+   // such flags.  It will come here directly, and any subsequent heritable flag
+   // will be treated in the natural way, farther down the line.
+   //
+   // But if NXN is set when we get here. we do something special.  First,
+   // we do the downstream call naturally, handling any NXN naturally.
+
+   if (ss->cmd.cmd_final_flags.bool_test_heritbits(INHERITFLAG_NXNMASK)) {
+      // Just do the call, with its NXN, and turning on the "stable" bit.
+      // This code is the only place where the "stable" bit gets turned on,
+      // because "stable" is not actually parsed normally.
+      ss->cmd.cmd_final_flags.set_heritbits(INHERITFLAG_STABLE);
+      move(ss, false, result);
+      return;
+   }
 
    if (ss->cmd.cmd_final_flags.test_for_any_herit_or_final_bit())
       fail("Illegal modifier before \"stable\".");
@@ -6020,7 +6037,7 @@ static void do_concept_inner_outer(
    setup *result) THROW_DECL
 {
    uint32_t livemask;
-   calldef_schema sch;
+   calldef_schema sch = schema_concentric;
    int rot = 0;
    int arg1 = parseptr->concept->arg1;
 
@@ -7644,7 +7661,7 @@ static void do_concept_meta(
       nocmd.cmd_misc3_flags |= CMD_MISC3__META_NOCMD;
 
       // Foo1 finds the boundaries of the first subconcept.  (Foo2 wil show the second subconcept.)
-      skipped_concept_info foo1(specialfirstptr ? specialfirstptr : parseptr->next);
+      skipped_concept_info foo1(specialfirstptr ? specialfirstptr : parseptr->next, key);
 
       if (foo1.m_heritflag != 0ULL) {
          result_of_skip = foo1.m_concept_with_root;
@@ -9500,9 +9517,17 @@ static void do_concept_concentric(
       ss->cmd.parseptr = parseptr;
       divided_setup_move(ss, map_code, phantest_ok, true, result);
       break;
-   case schema_intermediate_diamond: case schema_outside_diamond:
+   case schema_intermediate_diamond:
       ss->cmd.cmd_misc3_flags |= CMD_MISC3__SAID_DIAMOND;
       concentric_move(ss, &sscmd, (setup_command *) 0, schema, 0,
+                      DFM1_CONC_CONCENTRIC_RULES, true, false, ~0U, result);
+
+      // 8-person concentric operations do not show the split.
+      result->result_flags.clear_split_info();
+      break;
+   case schema_outside_diamond:
+      ss->cmd.cmd_misc3_flags |= CMD_MISC3__SAID_DIAMOND;
+      concentric_move(ss, (setup_command *) 0, &sscmd, schema, 0,
                       DFM1_CONC_CONCENTRIC_RULES, true, false, ~0U, result);
 
       // 8-person concentric operations do not show the split.
@@ -9591,11 +9616,13 @@ extern bool do_big_concept(
    remove_z_distortion(ss);
 
    void (*concept_func)(setup *, parse_block *, setup *);
-   parse_block *this_concept_parse_block = the_concept_parse_block;
-   const concept_descriptor *this_concept = this_concept_parse_block->concept;
+   // Make a local copy; we may need to modify it.
+   parse_block local_concept_parse_block = *the_concept_parse_block;
+   const concept_descriptor *this_concept = local_concept_parse_block.concept;
    concept_kind this_kind = this_concept->kind;
    const concept_table_item *this_table_item = &concept_table[this_kind];
-   const uint32_t prop_bits = this_table_item->concept_prop;
+
+   uint32_t prop_bits = this_table_item->concept_prop;
 
    if (this_kind == concept_multiple_diamonds ||
        this_kind == concept_in_out_nostd ||
@@ -9722,7 +9749,7 @@ extern bool do_big_concept(
       // by going over the "standard" and skipping comments.
 
       junk_concepts.clear_all_herit_and_final_bits();
-      substandard_concptptr = process_final_concepts(the_concept_parse_block->next,
+      substandard_concptptr = process_final_concepts(local_concept_parse_block.next,
                                                      true, &junk_concepts,
                                                      true, false);
 
@@ -9773,7 +9800,7 @@ extern bool do_big_concept(
 
       uint32_t tbonetest;
       uint32_t stdtest;
-      int livemask = get_standard_people(ss, this_concept_parse_block->options.who.who[0],
+      int livemask = get_standard_people(ss, local_concept_parse_block.options.who.who[0],
                                          tbonetest, stdtest);
 
       if (!tbonetest) {
@@ -9864,7 +9891,7 @@ extern bool do_big_concept(
       doing_select = (prop_bits & CONCPROP__USE_SELECTOR) != 0;
 
       if (doing_select) {
-         current_options.who = this_concept_parse_block->options.who;
+         current_options.who = local_concept_parse_block.options.who;
       }
 
       for (i=0, j=1; i<=attr::slimit(ss); i++, j<<=1) {
@@ -9895,9 +9922,9 @@ extern bool do_big_concept(
          this_kind == concept_special_sequential_sel_no_2nd))
       ss->cmd.cmd_misc3_flags &= ~CMD_MISC3__PARTS_OVER_THIS_CONCEPT;
 
-   ss->cmd.parseptr->concentric_4p = this_concept_parse_block->concentric_4p;
+   ss->cmd.parseptr->concentric_4p = local_concept_parse_block.concentric_4p;
 
-   (*concept_func)(ss, this_concept_parse_block, result);
+   (*concept_func)(ss, &local_concept_parse_block, result);
    remove_tgl_distortion(result);
    // Beware -- result is not necessarily canonicalized.
    if (!(prop_bits & CONCPROP__SHOW_SPLIT))
@@ -10038,7 +10065,7 @@ const concept_table_item concept_table[] = {
     do_concept_single_diagonal},                            // concept_single_diagonal
    {CONCPROP__NO_STEP | CONCPROP__STANDARD,
     do_concept_double_diagonal},                            // concept_double_diagonal
-   {CONCPROP__GET_MASK,
+   {CONCPROP__GET_MASK | CONCPROP__MATRIX_OBLIVIOUS,
     do_concept_parallelogram},                              // concept_parallelogram
    {CONCPROP__NEED_ARG2_MATRIX | Standard_matrix_phantom,
     do_concept_multiple_lines},                             // concept_multiple_lines

--- a/src/sdistort.cpp
+++ b/src/sdistort.cpp
@@ -3153,7 +3153,8 @@ extern void distorted_move(
    int8_t the_map[8];
    const parse_block *next_parseptr;
    final_and_herit_flags junk_concepts;
-   int rot, rotz;
+   int rot = 0;
+   int rotz = 0;
    setup_kind k;
    setup a1;
    setup res1;
@@ -3806,7 +3807,7 @@ extern void triple_twin_move(
 {
    ss->clear_all_overcasts();
    uint32_t tbonetest = global_tbonetest;
-   uint32_t mapcode;
+   uint32_t mapcode = 0;
    phantest_kind phan = (phantest_kind) parseptr->concept->arg4;
 
    // Arg1 = 0/1/3 for C/L/W, usual coding.

--- a/src/sdmain.cpp
+++ b/src/sdmain.cpp
@@ -44,8 +44,8 @@
 //    string is also required by paragraphs 2(a) and 2(c) of the GNU
 //    General Public License if you distribute the file.
 
-#define VERSION_STRING "39.83"
-#define TIME_STAMP "wba@alum.mit.edu Mar 25 2026 $"
+#define VERSION_STRING "39.84"
+#define TIME_STAMP "wba@alum.mit.edu Jul 4 2026 $"
 
 /* This defines the following functions:
    sd_version_string
@@ -433,7 +433,7 @@ static bool find_numbers(int howmanynumbers, bool forbid_zero,
 extern bool deposit_call(call_with_name *call, const call_conc_option_state *options)
 {
    parse_block *new_block;
-   call_with_name *tagger_call;
+   call_with_name *tagger_call = (call_with_name *) 0;
    uint32_t tagg = 0;
    who_list sel;
    direction_kind dir = direction_uninitialized;

--- a/src/sdmatch.cpp
+++ b/src/sdmatch.cpp
@@ -476,7 +476,7 @@ void matcher_class::do_accelerator_spec(Cstring inputline, bool is_accelerator)
    if (!inputline[0] || inputline[0] == '\r' || inputline[0] == '\n' || inputline[0] == '#') return;   // This is a blank line or a comment.
 
    char key_name[MAX_FILENAME_LENGTH];
-   char *key_org;
+   char *key_org = (char *) 0;
    char junk_name[MAX_FILENAME_LENGTH];
    int ccount;
    int menu_type = call_list_any;
@@ -553,7 +553,7 @@ void matcher_class::do_accelerator_spec(Cstring inputline, bool is_accelerator)
    }
 
    if (is_accelerator) {
-      modifier_block **table_thing;
+      modifier_block **table_thing = (modifier_block **) 0;
 
       if (m_active_result.match.kind == ui_start_select) {
          table_thing = &m_fcn_key_table_start[keybindcode-FCN_KEY_TAB_LOW];
@@ -578,7 +578,7 @@ void matcher_class::do_accelerator_spec(Cstring inputline, bool is_accelerator)
       *table_thing = newthing;
    }
    else {
-      abbrev_block **table_thing;
+      abbrev_block **table_thing = (abbrev_block **) 0;
 
       if (m_active_result.match.kind == ui_start_select) {
          table_thing = &m_abbrev_table_start;
@@ -1986,7 +1986,8 @@ void matcher_class::match_pattern(Cstring pattern)
 
 void matcher_class::search_menu(uims_reply_kind kind)
 {
-   unsigned int i, menu_length;
+   unsigned int i;
+   unsigned int menu_length = 0;
    Cstring *menu;
    char uch = m_user_input[0];
    bool input_is_null = uch == '\0' && !m_showing;

--- a/src/sdmoves.cpp
+++ b/src/sdmoves.cpp
@@ -1498,9 +1498,10 @@ static int start_matrix_call(
 
    // For trade, we use the accurate info.  You're not allowed to press or truck
    // across the points of an hourglass, but you are allowed to trade.
-   if (the_schema == schema_counter_rotate || (flags & MTX_FIND_TRADERS) != 0) {
-      thingyptr = (ss->kind == s_qtag) ?
-         &supernicethingqtag : nicethingyptr;
+   if (((flags & MTX_FIND_JAYWALKERS) == 0) &&
+       (the_schema == schema_counter_rotate || the_schema == schema_partner_matrix ||
+        the_schema == schema_partner_partial_matrix || (flags & MTX_FIND_TRADERS) != 0)) {
+      thingyptr = (ss->kind == s_qtag) ? &supernicethingqtag : nicethingyptr;
    }
 
    if (flags & (MTX_FIND_SQUEEZERS|MTX_FIND_SPREADERS)) {
@@ -2523,6 +2524,7 @@ static int finish_matrix_call(
    const uint32_t *callstuff,
    bool do_roll_stability,
    collision_severity allow_collisions,
+   bool beware_mystic_collision,
    bool allow_fudging,
    merge_action_type action,
    setup *people,
@@ -2740,6 +2742,7 @@ static int finish_matrix_call(
    result->kind = checkptr->result_kind;
 
    collision_collector CC(result, allow_collisions);
+   CC.m_beware_mystic_collision = beware_mystic_collision;
 
    for (i=0; i<nump; i++) {
       int mx, my;
@@ -3017,7 +3020,7 @@ static int matrixmove(
    // mechanism.  In this case the MTX_FIND_TRADERS flag is on.
    int alldelta = finish_matrix_call(ss, matrix_info, nump, the_schema, flags, callstuff, true,
                                      (flags & MTX_FIND_TRADERS) ? collision_severity_ok : collision_severity_no,
-                                     true, merge_strict_matrix, &people, result);
+                                     false, true, merge_strict_matrix, &people, result);
 
    if (ss->kind == s2x2 && result->kind == s2x4) {
       if ((result->people[0].id1 | result->people[1].id1 | result->people[6].id1 | result->people[7].id1) == 0) {
@@ -3339,7 +3342,7 @@ static int jaywalk_recurse(
 {
    int i, j, k;
    matrix_rec best_info[matrix_info_capacity+1];
-   int best_cost;
+   int best_cost = 0;
 
    // Pre-clean: Clear out any links that aren't bidirectional.
    // First, mark all targets.
@@ -3393,7 +3396,7 @@ static int jaywalk_recurse(
       }
 
       if (choice_count >= 2) {
-         int cost_or_error_code;
+         int cost_or_error_code = 0;
          bool found_a_solution = false;
          bool ambiguous = false;
 
@@ -3682,7 +3685,7 @@ static int partner_matrixmove(
    }
 
    int alldelta = finish_matrix_call(ss, matrix_info, nump, the_schema, flags, (const uint32_t *) 0, true, collision_severity_no,
-                                     true, merge_strict_matrix, &people, result);
+                                     false, true, merge_strict_matrix, &people, result);
    reinstate_rotation(ss, result);
 
    // Take out any active phantoms that we placed.
@@ -3702,11 +3705,13 @@ static int partner_matrixmove(
 // This treats res2 as though it had rotation zero.
 // Res1 is allowed to have rotation.
 extern void brute_force_merge(const setup *res1, const setup *res2,
-                              merge_action_type action, setup *result) THROW_DECL
+                              merge_action_type action, bool beware_mystic_collision,
+                              setup *result) THROW_DECL
 {
    int i;
    int r = res1->rotation & 3;
    collision_severity allow_collisions = collision_severity_no;
+
    if (action > merge_for_own)
       allow_collisions = collision_severity_ok;
    else if (action == merge_for_own)
@@ -3747,7 +3752,7 @@ extern void brute_force_merge(const setup *res1, const setup *res2,
       // "do_roll_stability" argument here.  It would treat the rotation
       // as though the person had actually done a call.
       finish_matrix_call((setup *) 0, matrix_info, nump, schema_matrix, 0, (const uint32_t *) 0, false, allow_collisions,
-                         action > merge_for_own, action, &people, result);
+                         beware_mystic_collision, action > merge_for_own, action, &people, result);
       return;
    }
 
@@ -3907,7 +3912,7 @@ extern void drag_someone_and_move(setup *ss, parse_block *parseptr, setup *resul
 
    ss->rotation += result->rotation;
    finish_matrix_call(ss, second_matrix_info, final_2nd_nump, schema_matrix, 0, (const uint32_t *) 0, true,
-                      collision_severity_no, true, merge_strict_matrix, &second_people, result);
+                      collision_severity_no, false, true, merge_strict_matrix, &second_people, result);
    reinstate_rotation(ss, result);
    clear_result_flags(result);
 }
@@ -4102,7 +4107,7 @@ static bool try_this_split(uint32_t splitting_indicator,
    }
 
    finish_matrix_call((setup *) 0, after_matrix_info, nump, schema_matrix, 0, (const uint32_t *) 0, false,
-                      collision_severity_no, true, merge_strict_matrix, &after_people, result);
+                      collision_severity_no, false, true, merge_strict_matrix, &after_people, result);
    return true;
 }
 

--- a/src/sdtables.cpp
+++ b/src/sdtables.cpp
@@ -2118,6 +2118,11 @@ map::map_thing map::map_init_table[] = {
    {{2, 3, 4, 5, 8, 9, 10, 11},
     s2x4,1,MPKIND__OFFS_R_HALF,1, warn__none,  s2x6,      0x000, 0},
 
+   {{0, 1, 2, 3, 4, 5, 6, 7,   12, 13, 14, 15, 16, 17, 18, 19},
+    s2x8,1,MPKIND__OFFS_L_HALF,1, warn__none,  s2x12,      0x000, 0},
+   {{4, 5, 6, 7, 8, 9, 10, 11,   16, 17, 18, 19, 20, 21, 22, 23},
+    s2x8,1,MPKIND__OFFS_R_HALF,1, warn__none,  s2x12,      0x000, 0},
+
    {{15, 16, 17, 3, 6, 7, 8, 12},
     s2x4,1,MPKIND__OFFSPG_L1,1, warn__none,  s3x6,      0x000, 0},
    {{2, 8, 7, 6, 11, 17, 16, 15},
@@ -4099,13 +4104,13 @@ full_expand::thing touch_init_table3[] = {
 // 100 bit: don't allow for synthesize; that is, you can go in, but you can't come out.
 // 80 bit: forbid synthesize if came from schema_rev_checkpoint_concept.
 // 40 bit: forbid synthesize if matrix concept was given.
+// 20 bit: forbid synthesize if outer_elongation = 3 and rotation different
+// 10 bit: forbid synthesize if outer_elongation = 3 and rotation same
 // Low 4 bits forbid synthesize if
 //   8: outside elongation is vertical and rotation different
 //   4: outside elongation is vertical and rotation same
 //   2: outside elongation is horizontal and rotation different
 //   1: outside elongation is horizontal and rotation same
-// 20 bit: forbid synthesize if outer_elongation = 3 and rotation different
-// 10 bit: forbid synthesize if outer_elongation = 3 and rotation same
 
 // First line:
 //   bigsetup    lyzer      ... maps .............
@@ -4218,9 +4223,22 @@ conc_tables::cm_thing conc_tables::conc_init_table[] = {
 
    {s3x1dmd,        schema_intermediate_diamond, {7, 1, 3, 5,         0, 2, 4, 6},
              sdmd,     s1x4,     1, 0, 1, 1,  0x8FD, schema_intermediate_diamond},
-   {s3x1dmd,        schema_outside_diamond, {7, 0, 3, 4,         1, 2, 5, 6},
-             sdmd,     s1x4,     1, 0, 1, 1,  0x8FD, schema_outside_diamond},
-   {s_crosswave,    schema_outside_diamond, {0, 2, 4, 6,         1, 3, 5, 7},
+
+   {s3x1dmd,        schema_outside_diamond, {1, 2, 5, 6,         7, 0, 3, 4},
+             s1x4,     sdmd,     0, 1, 1, 1,  0x8DF, schema_outside_diamond},
+   {s3x1dmd,        schema_outside_diamond, {1, 2, 5, 6,         7, 0, 3, 4},
+             s1x4,     sdmd,     0, 1, 0, 1,  0x8F7, schema_outside_diamond},
+
+   {s3x1dmd,        schema_outside_diamond, {1, 2, 5, 6,         0, 3, 4, 7},
+             s1x4,     sdmd,     0, 0, 1, 1,  0xAEF, schema_outside_diamond},
+
+   {s1x8,           schema_outside_diamond, {3, 2, 7, 6,         0, 1, 4, 5},
+             s1x4,     s1x4,     0, 0, 1, 1,  0x8FA, schema_outside_diamond},
+
+   {s_crosswave,    schema_outside_diamond, {6, 7, 2, 3,         0, 1, 4, 5},
+             s1x4,     s1x4,     1, 0, 1, 1,  0x8F7, schema_outside_diamond},
+
+   {s_crosswave,    schema_outside_diamond, {1, 3, 5, 7,         0, 2, 4, 6},
              sdmd,     sdmd,     0, 0, 1, 1,  0x8FE, schema_outside_diamond},
 
    {s_wingedstar,   schema_intermediate_diamond, {1, 3, 5, 7,         0, 2, 4, 6},
@@ -4231,20 +4249,26 @@ conc_tables::cm_thing conc_tables::conc_init_table[] = {
    // For putting back shape-changers.
    {s1x3dmd,        schema_intermediate_diamond, {1, 3, 5, 7,         0, 2, 4, 6},
              sdmd,     s1x4,     0, 0, 1, 1,  0x8FE, schema_intermediate_diamond},
-   {s1x3dmd,        schema_outside_diamond, {0, 3, 4, 7,         1, 2, 5, 6},
-             sdmd,     s1x4,     0, 0, 1, 1,  0x8FE, schema_outside_diamond},
+   {s1x3dmd,        schema_outside_diamond, {1, 2, 5, 6,         0, 3, 4, 7},
+             s1x4,     sdmd,     0, 0, 1, 1,  0x8FE, schema_outside_diamond},
    {s_crosswave,    schema_nothing, {6, 7, 2, 3,         0, 1, 4, 5},
              s1x4,     s1x4,     1, 0, 1, 1,  0x8FD, schema_intermediate_diamond},
+   {s1x8,           schema_nothing, {3, 2, 7, 6,         0, 1, 4, 5},
+             s1x4,     s1x4,     0, 0, 1, 1,  0x8EF, schema_outside_diamond},
+   // previously                              0xAFE
+
    {s_crosswave,    schema_nothing, {6, 7, 2, 3,         0, 1, 4, 5},
              s1x4,     s1x4,     1, 0, 1, 1,  0x8FD, schema_outside_diamond},
+   {s_crosswave,    schema_nothing, {6, 7, 2, 3,         0, 1, 4, 5},
+             s1x4,     s1x4,     1, 0, 1, 1,  0x8DF, schema_outside_diamond},
    {s_ptpd,         schema_nothing, {1, 7, 5, 3,         0, 2, 4, 6},
              s2x2,     s1x4,     0, 0, 1, 1,  0xAFE, schema_intermediate_diamond},
-   {s_bone,         schema_nothing, {0, 1, 4, 5,         6, 7, 2, 3},
-             s2x2,     s1x4,     0, 0, 1, 1,  0xAFE, schema_outside_diamond},
+   {s_bone,         schema_nothing, {6, 7, 2, 3,         0, 1, 4, 5},
+             s1x4,     s2x2,     0, 0, 1, 1,  0xAFE, schema_outside_diamond},
+   {s_qtag,         schema_nothing, {6, 7, 2, 3,         0, 1, 4, 5},
+             s1x4,     s2x2,     0, 0, 1, 1,  0x8EF, schema_outside_diamond},
    {s1x8,           schema_nothing, {1, 3, 5, 7,         0, 2, 4, 6},
              s1x4,     s1x4,     0, 0, 1, 1,  0xAFE, schema_intermediate_diamond},
-   {s1x8,           schema_nothing, {0, 1, 4, 5,         3, 2, 7, 6},
-             s1x4,     s1x4,     0, 0, 1, 1,  0xAFE, schema_outside_diamond},
 
    {s3ptpd,         schema_nothing,            {9, -1, 10, -1, 4, -1, 3, -1,        11, 1, 5, 7},
              s1x4,     sdmd,     0, 0, 1, 2,  0xAFE, schema_in_out_triple},
@@ -11248,6 +11272,7 @@ const schema_attr schema_attrs[] = {
 
 // BEWARE!!  This list is keyed to the definition of "meta_key_kind" in sd.h .
 const uint32_t meta_key_props[] = {
+   0,                                 // meta_key_none
    MKP_RESTRAIN_1 | MKP_RESTRAIN_2,   // meta_key_random
    MKP_RESTRAIN_1 | MKP_RESTRAIN_2,   // meta_key_rev_random
    MKP_RESTRAIN_1 | MKP_RESTRAIN_2,   // meta_key_piecewise

--- a/src/sdtand.cpp
+++ b/src/sdtand.cpp
@@ -3399,7 +3399,7 @@ void mimic_move(
    int trial_number;
    setup trial_results[2];
    int trial_result_mask = 0;
-   error_flag_type err_from_execution;
+   error_flag_type err_from_execution = (error_flag_type) 0;
 
    switch (who) {
    case selector_centers:

--- a/src/sdtop.cpp
+++ b/src/sdtop.cpp
@@ -1569,8 +1569,6 @@ void setup::do_matrix_expansion(
                goto expanded;
             }
          }
-
-
          else if (needpropbits & (NB(CONCPROP__NEEDK_TWINDMD) | NB(CONCPROP__NEEDK_TWINQTAG))) {
             // Egads!  It turns out that the "CONCPROP__NEEDK_TWINQTAG"
             // indicator is used not just for "twin phantom 1/4 tags", but for
@@ -3650,7 +3648,7 @@ bool check_for_concept_group(
        (get_meta_key_props(this_concept) & MKP_RESTRAIN_1))
       retstuff.m_need_to_restrain |= 1;
 
-   parse_block *skip_a_pair = (parse_block *) 0;
+   parse_block *double_skip = (parse_block *) 0;
    final_and_herit_flags junk_concepts;
 
    junk_concepts.clear_all_herit_and_final_bits();
@@ -3658,7 +3656,7 @@ bool check_for_concept_group(
 
    if (temp && temp != parseptrcopy && temp->concept->kind == concept_concentric &&
        !junk_concepts.bool_test_heritbits(~(INHERITFLAG_GRAND|INHERITFLAG_SINGLE|INHERITFLAG_CROSS))) {
-         skip_a_pair = temp;
+         double_skip = temp;
    }
    else {
       junk_concepts.clear_all_herit_and_final_bits();
@@ -3671,7 +3669,7 @@ bool check_for_concept_group(
             if ((temp->concept->kind == concept_tandem ||
                  temp->concept->kind == concept_frac_tandem) &&
                 (!junk_concepts.test_for_any_herit_or_final_bit())) {
-               skip_a_pair = temp;
+               double_skip = temp;
             }
          }
          else if (k == concept_snag_mystic && (this_concept->arg1 & CMD_MISC2__CENTRAL_MYSTIC)) {
@@ -3682,7 +3680,7 @@ bool check_for_concept_group(
                  temp->concept->kind == concept_multiple_boxes) &&
                 temp->concept->arg4 == 3 &&
                 (!junk_concepts.test_for_any_herit_or_final_bit())) {
-               skip_a_pair = temp;
+               double_skip = temp;
             }
          }
          else if (k == concept_parallelogram ||
@@ -3696,27 +3694,32 @@ bool check_for_concept_group(
                  temp->concept->kind == concept_do_phantom_boxes) &&
                 temp->concept->arg3 == MPKIND__SPLIT &&
                 (!junk_concepts.test_for_any_herit_or_final_bit())) {
-               skip_a_pair = temp;
+               // But not if being done "initially" or whatever.
+               // In that case the "parallelogram" (or whatever) and the
+               // "split phantom waves (or whatever)" are treated as one concept.
+               if (retstuff.m_meta_key != meta_key_nth_part_work &&
+                   retstuff.m_meta_key != meta_key_echo)
+                  double_skip = temp;
             }
          }
          else if (get_meta_key_props(this_concept) & MKP_RESTRAIN_2) {
             // Look for combinations like "random/initially/echo/nth-part-work <concept>".
-            skip_a_pair = parseptr_skip;
+            double_skip = parseptr_skip;
          }
          else if (k == concept_so_and_so_only &&
                   ((selective_key) parseptrcopy->concept->arg1) == selective_key_work_concept) {
             // Look for combinations like "<anyone> work <concept>".
-            skip_a_pair = parseptr_skip;
+            double_skip = parseptr_skip;
          }
          else if (k == concept_matrix) {
-            skip_a_pair = parseptr_skip;
+            double_skip = parseptr_skip;
          }
       }
    }
 
-   if (skip_a_pair) {
-      parseptrcopy = skip_a_pair;
-      next_parseptr = skip_a_pair;
+   if (double_skip) {
+      parseptrcopy = double_skip;
+      next_parseptr = double_skip;
       retval = true;
       goto try_again;
    }
@@ -4574,6 +4577,9 @@ extern callarray *assoc(
       case cr_didnt_say_matrix:
          if (ss->cmd.cmd_misc_flags & CMD_MISC__EXPLICIT_MATRIX) goto bad;
          goto good;
+      case cr_phantom_in_use:
+         if (ss->cmd.cmd_misc_flags & CMD_MISC__PHANTOMS) goto good;
+         goto bad;
       case cr_occupied_as_h:
          if (ssK != s3x4 ||
              (ss->people[1].id1 | ss->people[2].id1 |
@@ -4836,7 +4842,8 @@ extern callarray *assoc(
          if (ssK == s2x4)
             goto good;
       case cr_people_1_opp_real:
-         if (ss->people[1].id1 != 0 && ss->people[(begin_size>>1)+1].id1 != 0) goto good;
+         if (ss->people[1].id1 != 0 && ss->people[(begin_size>>1)+1].id1 != 0)
+            goto good;
          goto bad;
       case cr_people_12_opp_real:
          if (ss->people[1].id1 != 0 && ss->people[(begin_size>>1)+1].id1 != 0 &&
@@ -4848,6 +4855,14 @@ extern callarray *assoc(
              ss->people[4].id1 != 0 && ss->people[(begin_size>>1)+4].id1 != 0) 
             goto good;
          goto bad;
+      case cr_people_0_opp_phan:
+         // We need 0 and 2 phantom, and, if this is of size 4, everyone else real.
+         // All kind of stupid.
+         if (begin_size == 4 && (ss->people[1].id1 == 0 || ss->people[3].id1 == 0))
+            goto bad;
+         if (ss->people[0].id1 != 0 || ss->people[(begin_size>>1)+0].id1 != 0)
+            goto bad;
+         goto good;
 
       case cr_slide_seems_good:
          {
@@ -5519,7 +5534,8 @@ parse_block *process_final_concepts(
 }
 
 
-skipped_concept_info::skipped_concept_info(parse_block *incoming) THROW_DECL
+skipped_concept_info::skipped_concept_info(parse_block *incoming,
+                                           meta_key_kind meta_key /* = meta_key_none */) THROW_DECL
 {
    if (!incoming)
       fail("Need a concept.");
@@ -5534,6 +5550,7 @@ skipped_concept_info::skipped_concept_info(parse_block *incoming) THROW_DECL
    m_result_of_skip = m_skipped_concept->next;
    m_need_to_restrain = 0;
    m_root_of_result_of_skip = (parse_block **) 0;
+   m_meta_key = meta_key;
 
    final_and_herit_flags junk_concepts;
    junk_concepts.clear_all_herit_and_final_bits();

--- a/src/sdutil.cpp
+++ b/src/sdutil.cpp
@@ -1728,9 +1728,9 @@ void ui_utils::print_recurse(parse_block *thing, int print_recurse_arg)
          // This is a "marker", so it has a call, perhaps with a selector and/or number.
          // The call may be null if we are printing a partially entered line.  Beware.
 
-         parse_block *sub1_ptr;
-         parse_block *sub2_ptr;
-         parse_block *search;
+         parse_block *sub1_ptr = (parse_block *) 0;
+         parse_block *sub2_ptr = (parse_block *) 0;
+         parse_block *search = (parse_block *) 0;
          bool pending_subst1, pending_subst2;
 
          parse_block *save_cptr = local_cptr;
@@ -2896,7 +2896,7 @@ selector_kind translate_selector_permutation2(uint32_t x)
 
 extern uint32_t translate_selector_fields(parse_block *xx, uint32_t mask)
 {
-   selector_kind z;
+   selector_kind z = selector_uninitialized;
    uint32_t retval = 0;
 
    for ( ; xx ; xx=xx->next) {
@@ -2966,7 +2966,7 @@ extern uint32_t translate_selector_fields(parse_block *xx, uint32_t mask)
       }
 
       if (z == selector_uninitialized) retval = 2;   // Raise error.
-      if (z != xx->options.who.who[0]) retval |= 1;         // Note that we changed something.
+      if (z != xx->options.who.who[0]) retval |= 1;  // Note that we changed something.
       xx->options.who.who[0] = z;
 
    nofix:


### PR DESCRIPTION
Changes in version 39.84

Took out the "no_uninitialized" flag for mingw64.

Deal with tricky aspects of split circulate.  Git #70.

Handle strut right/left with single stable in big matrix.  Git #37

Fix bug in zip the top.

Improve mesh.

Improve roll out to a column.

Improve lock 'em up, Git #68.

Improve interlocked _fold to face, Git #67.

Fix the wrong-handed collision in the action, Git #7.

Improved handling of stable.  It's a heritable flag in some cases.  Git #37.

Improved handling of outside diamonds, Git #76.

Treat "parallelogram" and "split phantom whatever" as a single concept when used under stuff like "initially", Git #62.